### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/stm32f4/timer.rs
+++ b/stm32f4/timer.rs
@@ -116,10 +116,11 @@ pub enum ClockDivision {
 
 impl Tim {
     pub fn init(&self, tim: &TimInit) {
-        unsafe {
-            let mut tmpcr1 = self.cr1.get();
+        
+            let mut tmpcr1 = unsafe { self.cr1.get() };
             tmpcr1 &= !(Cr1::DIR as u32 | Cr1::CMS as u32);
             tmpcr1 |= tim.counter_mode as u32;
+        unsafe {
             self.cr1.set(tmpcr1);
 
             self.arr.set(tim.period);
@@ -157,11 +158,11 @@ impl Tim {
     }
 
     pub fn it_status(&self, it: Dier) -> bool {
-        unsafe {
-            let itstatus = self.sr.get() & it as u32;
-            let itenable = self.dier.get() & it as u32;
+        
+            let itstatus = unsafe { self.sr.get() } & it as u32;
+            let itenable = unsafe { self.dier.get() } & it as u32;
             itstatus != 0 && itenable != 0
-        }
+        
     }
 
     pub fn it_clear_pending(&self, it: Dier) {

--- a/stm32f4/usart.rs
+++ b/stm32f4/usart.rs
@@ -276,7 +276,7 @@ impl Usart {
     }
 
     pub fn it_enabled(&self, it: Interrupt) -> bool {
-        unsafe {
+        
             let itpos = it as u32 & 0x001F;
             let itmask = 0x01 << itpos;
 
@@ -287,12 +287,12 @@ impl Usart {
                 _ => &self.cr3,
             };
 
-            itmask & reg.get() != 0
-        }
+            itmask & unsafe {reg.get()} != 0
+        
     }
 
     pub fn it_status(&self, it: Interrupt) -> bool {
-        unsafe {
+        
             let itpos = it as u32 & 0x001F;
             let mut itmask = 0x01 << itpos;
 
@@ -303,22 +303,22 @@ impl Usart {
                 _ => &self.cr3,
             };
 
-            itmask &= reg.get();
+            itmask &= unsafe { reg.get() };
 
             let mut bitpos = it as u32 >> 8;
             bitpos = 0x01 << bitpos;
-            bitpos &= self.sr.get();
+            bitpos &= unsafe { self.sr.get() };
 
             bitpos != 0 && itmask != 0
-        }
+        
     }
 
     pub fn it_clear_pending(&self, it: Interrupt) {
-        unsafe {
+        
             let bitpos = it as u32 >> 8;
             let itmask = 1_u16 << bitpos;
-            self.sr.set(u32::from(!itmask));
-        }
+            unsafe { self.sr.set(u32::from(!itmask)) };
+        
     }
 }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
@rasendubi
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 